### PR TITLE
Add jsonc support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  extends: ['fritx', 'fritx/node', 'fritx/es5-loose'],
+  ignorePatterns: [
+    // third-party libraries
+    'strip-json-comments/**/*.js'
+  ],
+  env: {
+    es6: true
+  },
+  parserOptions: {
+    ecmaVersion: 6
+  },
+  rules: {
+    'es5/no-block-scoping': 0,
+    'object-curly-spacing': 0,
+    'padded-blocks': 0,
+    camelcase: 0
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  // https://github.com/antfu/eslint-config#config-vs-code-auto-fix
+  // https://github.com/prettier/prettier-vscode#default-formatter
+  "prettier.enable": false,
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ $ npm install --save jsonmerge
 
 ```javascript
 const jsonmerge = require('jsonmerge')
-
 let result = jsonmerge(['./test/fixtures/json/*.json'])
+
+// or with jsonc support
+const jsonmerge = require('jsonmerge/jsonc')
+let result = jsonmerge(['./test/fixtures/jsonc/*.json'])
+
 console.log(JSON.stringify(result, null, 4))
 ```
 
@@ -26,6 +30,9 @@ console.log(JSON.stringify(result, null, 4))
 ```shell
 $ cd test/fixtures
 $ jsonmerge json/*.json > result.json
+
+# or with jsonc support
+$ jsonmerge --jsonc jsonc/*.json > result.json
 ```
 
 ## License 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jsonmerge [![v](https://img.shields.io/npm/v/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge)
+# jsonmerge [![v](https://img.shields.io/npm/v/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge) [![dm](https://img.shields.io/npm/dm/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge)
 
 ## Install 
 

--- a/bin/jsonmerge.js
+++ b/bin/jsonmerge.js
@@ -3,13 +3,18 @@
 'use strict'
 const program = require('commander')
 const pkg = require('../package.json')
-const jsonmerge = require('../')
 
 program
   .version(pkg.version)
   .arguments('[source...]')
+  .option('--jsonc', 'enable parseing with jsonc syntax')
   .description('merge the source json file to dest json file')
   .action(function (source, options) {
+
+    // picking up the right module dynamically
+    // to avoid unnecessary dependencies loading
+    let jsonmerge = options.jsonc ? require('../jsonc.js') : require('../')
+
     let result = jsonmerge(source)
     console.log(JSON.stringify(result, null, 4))
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const fs = require('fs')
 const _ = require('lodash')
 const glob = require('glob')
 
-module.exports = function (source) {
+module.exports = function (source, options) {
+  options = options || {}
+
   let result = {}
   if (source && source.length >= 1) {
     
@@ -16,6 +18,9 @@ module.exports = function (source) {
 
     jsonFiles.forEach(function (json_file) {
       let json_string = fs.readFileSync(json_file, {encoding: 'utf-8'})
+      if (options.transform) {
+        json_string = options.transform(json_string)
+      }
       result = _.merge(result, JSON.parse(json_string))
     })
   }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (source, options) {
 
   let result = {}
   if (source && source.length >= 1) {
-    
+
     let jsonFiles = []
 
     source.forEach(function (pattern) {
@@ -25,4 +25,4 @@ module.exports = function (source, options) {
     })
   }
   return result
-} 
+}

--- a/jsonc.js
+++ b/jsonc.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const jsonmerge = require('./')
+const stripJsonComments = require('./strip-json-comments')
+const stripJsonTrailingCommasPkg = require('strip-json-trailing-commas')
+
+const stripJsonTrailingCommas = stripJsonTrailingCommasPkg.default
+
+module.exports = function (source, options) {
+  let newOptions = Object.assign({}, options, {
+    transform: function (json_string) {
+      // note: `jsonc.parse` cannot handle trailing commas
+      // use `stripJsonComments + stripJsonTrailingCommas` instead
+      json_string = stripJsonComments(json_string)
+      return stripJsonTrailingCommas(json_string)
+    }
+  })
+  return jsonmerge(source, newOptions)
+}

--- a/jsonc.js
+++ b/jsonc.js
@@ -3,11 +3,12 @@
 const jsonmerge = require('./')
 const stripJsonComments = require('./strip-json-comments')
 const stripJsonTrailingCommasPkg = require('strip-json-trailing-commas')
+const _ = require('lodash')
 
 const stripJsonTrailingCommas = stripJsonTrailingCommasPkg.default
 
 module.exports = function (source, options) {
-  let newOptions = Object.assign({}, options, {
+  let newOptions = _.assign({}, options, {
     transform: function (json_string) {
       // note: `jsonc.parse` cannot handle trailing commas
       // use `stripJsonComments + stripJsonTrailingCommas` instead

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "merge json file",
   "main": "index.js",
   "scripts": {
+    "lint:fix": "eslint . --fix",
+    "lint": "eslint .",
     "test": "xv"
   },
   "bin": {
@@ -31,6 +33,9 @@
     "strip-json-trailing-commas": "^1.1.0"
   },
   "devDependencies": {
+    "eslint": "^8.25.0",
+    "eslint-config-fritx": "^0.0.3",
+    "eslint-plugin-es5": "^1.5.0",
     "xv": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "merge json file",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "xv"
   },
   "bin": {
     "jsonmerge": "bin/jsonmerge.js"
@@ -29,5 +29,8 @@
     "glob": "^6.0.4",
     "lodash": "^4.3.0",
     "strip-json-trailing-commas": "^1.1.0"
+  },
+  "devDependencies": {
+    "xv": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "glob": "^6.0.4",
-    "lodash": "^4.3.0"
+    "lodash": "^4.3.0",
+    "strip-json-trailing-commas": "^1.1.0"
   }
 }

--- a/strip-json-comments/index.js
+++ b/strip-json-comments/index.js
@@ -1,0 +1,112 @@
+/**
+ * MIT License
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ * modification: downgrade ESM to CJS
+ */
+const singleComment = Symbol('singleComment');
+const multiComment = Symbol('multiComment');
+
+const stripWithoutWhitespace = () => '';
+const stripWithWhitespace = (string, start, end) => string.slice(start, end).replace(/\S/g, ' ');
+
+const isEscaped = (jsonString, quotePosition) => {
+	let index = quotePosition - 1;
+	let backslashCount = 0;
+
+	while (jsonString[index] === '\\') {
+		index -= 1;
+		backslashCount += 1;
+	}
+
+	return Boolean(backslashCount % 2);
+};
+
+module.exports = function stripJsonComments(jsonString, {whitespace = true, trailingCommas = false} = {}) {
+	if (typeof jsonString !== 'string') {
+		throw new TypeError(`Expected argument \`jsonString\` to be a \`string\`, got \`${typeof jsonString}\``);
+	}
+
+	const strip = whitespace ? stripWithWhitespace : stripWithoutWhitespace;
+
+	let isInsideString = false;
+	let isInsideComment = false;
+	let offset = 0;
+	let buffer = '';
+	let result = '';
+	let commaIndex = -1;
+
+	for (let index = 0; index < jsonString.length; index++) {
+		const currentCharacter = jsonString[index];
+		const nextCharacter = jsonString[index + 1];
+
+		if (!isInsideComment && currentCharacter === '"') {
+			// Enter or exit string
+			const escaped = isEscaped(jsonString, index);
+			if (!escaped) {
+				isInsideString = !isInsideString;
+			}
+		}
+
+		if (isInsideString) {
+			continue;
+		}
+
+		if (!isInsideComment && currentCharacter + nextCharacter === '//') {
+			// Enter single-line comment
+			buffer += jsonString.slice(offset, index);
+			offset = index;
+			isInsideComment = singleComment;
+			index++;
+		} else if (isInsideComment === singleComment && currentCharacter + nextCharacter === '\r\n') {
+			// Exit single-line comment via \r\n
+			index++;
+			isInsideComment = false;
+			buffer += strip(jsonString, offset, index);
+			offset = index;
+			continue;
+		} else if (isInsideComment === singleComment && currentCharacter === '\n') {
+			// Exit single-line comment via \n
+			isInsideComment = false;
+			buffer += strip(jsonString, offset, index);
+			offset = index;
+		} else if (!isInsideComment && currentCharacter + nextCharacter === '/*') {
+			// Enter multiline comment
+			buffer += jsonString.slice(offset, index);
+			offset = index;
+			isInsideComment = multiComment;
+			index++;
+			continue;
+		} else if (isInsideComment === multiComment && currentCharacter + nextCharacter === '*/') {
+			// Exit multiline comment
+			index++;
+			isInsideComment = false;
+			buffer += strip(jsonString, offset, index + 1);
+			offset = index + 1;
+			continue;
+		} else if (trailingCommas && !isInsideComment) {
+			if (commaIndex !== -1) {
+				if (currentCharacter === '}' || currentCharacter === ']') {
+					// Strip trailing comma
+					buffer += jsonString.slice(offset, index);
+					result += strip(buffer, 0, 1) + buffer.slice(1);
+					buffer = '';
+					offset = index;
+					commaIndex = -1;
+				} else if (currentCharacter !== ' ' && currentCharacter !== '\t' && currentCharacter !== '\r' && currentCharacter !== '\n') {
+					// Hit non-whitespace following a comma; comma is not trailing
+					buffer += jsonString.slice(offset, index);
+					offset = index;
+					commaIndex = -1;
+				}
+			} else if (currentCharacter === ',') {
+				// Flush buffer prior to this point, and save new comma index
+				result += buffer + jsonString.slice(offset, index);
+				buffer = '';
+				offset = index;
+				commaIndex = index;
+			}
+		}
+	}
+
+	return result + buffer + (isInsideComment ? strip(jsonString.slice(offset)) : jsonString.slice(offset));
+}

--- a/strip-json-comments/license
+++ b/strip-json-comments/license
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/test/api.default.test.js
+++ b/test/api.default.test.js
@@ -2,22 +2,22 @@ const assert = require('assert')
 const helper = require('./helper')
 const jsonmerge = require('..')
 
-exports.testJson = () => {
+exports.testJson = function () {
   let res = jsonmerge(['test/fixtures/json/*.json'])
   assert.deepEqual(res, helper.apiExpected)
 }
 
-exports.testMultiplePatterns = () => {
+exports.testMultiplePatterns = function () {
   let res = jsonmerge(['test/fixtures/json/a.json', 'test/fixtures/json/{b,c}.json'])
   assert.deepEqual(res, helper.apiExpected)
 }
 
-exports.testEmptyInput = () => {
+exports.testEmptyInput = function () {
   let res = jsonmerge(['test/fixtures/nothing/*.json'])
   assert.deepEqual(res, {})
 }
 
-exports.testJsonc = () => {
+exports.testJsonc = function () {
   assert.throws(function () {
     jsonmerge(['test/fixtures/jsonc/*.json'])
   }, /SyntaxError: Unexpected token/)

--- a/test/api.default.test.js
+++ b/test/api.default.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert')
+const helper = require('./helper')
+const jsonmerge = require('..')
+
+exports.testJson = () => {
+  let res = jsonmerge(['test/fixtures/json/*.json'])
+  assert.deepEqual(res, helper.apiExpected)
+}
+
+exports.testMultiplePatterns = () => {
+  let res = jsonmerge(['test/fixtures/json/a.json', 'test/fixtures/json/{b,c}.json'])
+  assert.deepEqual(res, helper.apiExpected)
+}
+
+exports.testEmptyInput = () => {
+  let res = jsonmerge(['test/fixtures/nothing/*.json'])
+  assert.deepEqual(res, {})
+}
+
+exports.testJsonc = () => {
+  assert.throws(function () {
+    jsonmerge(['test/fixtures/jsonc/*.json'])
+  }, /SyntaxError: Unexpected token/)
+}

--- a/test/api.jsonc.test.js
+++ b/test/api.jsonc.test.js
@@ -2,22 +2,22 @@ const assert = require('assert')
 const helper = require('./helper')
 const jsonmerge = require('../jsonc')
 
-exports.testJsonc = () => {
+exports.testJsonc = function () {
   let res = jsonmerge(['test/fixtures/jsonc/*.json'])
   assert.deepEqual(res, helper.apiExpected)
 }
 
-exports.testMultiplePatterns = () => {
+exports.testMultiplePatterns = function () {
   let res = jsonmerge(['test/fixtures/jsonc/a.json', 'test/fixtures/jsonc/{b,c}.json'])
   assert.deepEqual(res, helper.apiExpected)
 }
 
-exports.testEmptyInput = () => {
+exports.testEmptyInput = function () {
   let res = jsonmerge(['test/fixtures/nothing/*.json'])
   assert.deepEqual(res, {})
 }
 
-exports.testJson = () => {
+exports.testJson = function () {
   let res = jsonmerge(['test/fixtures/json/*.json'])
   assert.deepEqual(res, helper.apiExpected)
 }

--- a/test/api.jsonc.test.js
+++ b/test/api.jsonc.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert')
+const helper = require('./helper')
+const jsonmerge = require('../jsonc')
+
+exports.testJsonc = () => {
+  let res = jsonmerge(['test/fixtures/jsonc/*.json'])
+  assert.deepEqual(res, helper.apiExpected)
+}
+
+exports.testMultiplePatterns = () => {
+  let res = jsonmerge(['test/fixtures/jsonc/a.json', 'test/fixtures/jsonc/{b,c}.json'])
+  assert.deepEqual(res, helper.apiExpected)
+}
+
+exports.testEmptyInput = () => {
+  let res = jsonmerge(['test/fixtures/nothing/*.json'])
+  assert.deepEqual(res, {})
+}
+
+exports.testJson = () => {
+  let res = jsonmerge(['test/fixtures/json/*.json'])
+  assert.deepEqual(res, helper.apiExpected)
+}

--- a/test/cli.default.test.js
+++ b/test/cli.default.test.js
@@ -1,25 +1,25 @@
 const assert = require('assert')
 const helper = require('./helper')
 
-exports.testJson = () => {
+exports.testJson = function () {
   let res = helper.cli(['json/*.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, helper.cliExpected)
 }
 
-exports.testMultiplePatterns = () => {
+exports.testMultiplePatterns = function () {
   let res = helper.cli(['json/a.json', 'json/{b,c}.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, helper.cliExpected)
 }
 
-exports.testEmptyInput = () => {
+exports.testEmptyInput = function () {
   let res = helper.cli(['nothing/*.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, '{}\n')
 }
 
-exports.testJsonc = () => {
+exports.testJsonc = function () {
   let res = helper.cli(['jsonc/*.json'])
   assert.equal(res.stdout, '')
   assert.match(res.stderr, /SyntaxError: Unexpected token/)

--- a/test/cli.default.test.js
+++ b/test/cli.default.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert')
+const helper = require('./helper')
+
+exports.testJson = () => {
+  let res = helper.cli(['json/*.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, helper.cliExpected)
+}
+
+exports.testMultiplePatterns = () => {
+  let res = helper.cli(['json/a.json', 'json/{b,c}.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, helper.cliExpected)
+}
+
+exports.testEmptyInput = () => {
+  let res = helper.cli(['nothing/*.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, '{}\n')
+}
+
+exports.testJsonc = () => {
+  let res = helper.cli(['jsonc/*.json'])
+  assert.equal(res.stdout, '')
+  assert.match(res.stderr, /SyntaxError: Unexpected token/)
+}

--- a/test/cli.jsonc.test.js
+++ b/test/cli.jsonc.test.js
@@ -1,24 +1,24 @@
 const assert = require('assert')
 const helper = require('./helper')
 
-exports.testJsonc = () => {
+exports.testJsonc = function () {
   let res = helper.cli(['--jsonc', 'jsonc/*.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, helper.cliExpected)
 }
 
-exports.testMultiplePatterns = () => {
+exports.testMultiplePatterns = function () {
   let res = helper.cli(['--jsonc', 'jsonc/a.json', 'jsonc/{b,c}.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, helper.cliExpected)
 }
-exports.testEmptyInput = () => {
+exports.testEmptyInput = function () {
   let res = helper.cli(['--jsonc', 'nothing/*.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, '{}\n')
 }
 
-exports.testJson = () => {
+exports.testJson = function () {
   let res = helper.cli(['--jsonc', 'json/*.json'])
   assert.equal(res.stderr, '')
   assert.equal(res.stdout, helper.cliExpected)

--- a/test/cli.jsonc.test.js
+++ b/test/cli.jsonc.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert')
+const helper = require('./helper')
+
+exports.testJsonc = () => {
+  let res = helper.cli(['--jsonc', 'jsonc/*.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, helper.cliExpected)
+}
+
+exports.testMultiplePatterns = () => {
+  let res = helper.cli(['--jsonc', 'jsonc/a.json', 'jsonc/{b,c}.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, helper.cliExpected)
+}
+exports.testEmptyInput = () => {
+  let res = helper.cli(['--jsonc', 'nothing/*.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, '{}\n')
+}
+
+exports.testJson = () => {
+  let res = helper.cli(['--jsonc', 'json/*.json'])
+  assert.equal(res.stderr, '')
+  assert.equal(res.stdout, helper.cliExpected)
+}

--- a/test/fixtures/jsonc/a.json
+++ b/test/fixtures/jsonc/a.json
@@ -1,0 +1,13 @@
+/**
+  * block
+  * commenting
+  */
+{
+    "name": "userA",
+    "number": "1",
+    "attrA": "A",
+    "info": {
+        "password": "passwordA"
+        // some comment
+    }
+}

--- a/test/fixtures/jsonc/b.json
+++ b/test/fixtures/jsonc/b.json
@@ -1,0 +1,14 @@
+// a comment
+{
+    "name": "userB",
+    /* some comment */
+    "number": "2",
+    "attrB": "B",
+    "info": {
+        "password": "passwordB"
+    }
+}
+/**
+  * block
+  * commenting
+  */

--- a/test/fixtures/jsonc/c.json
+++ b/test/fixtures/jsonc/c.json
@@ -1,0 +1,15 @@
+{
+    /**
+     * block
+     * commenting
+     */
+    "name": "userC",
+    "number": "3",
+    "attrC": "c",
+    // a comment
+    "info": {
+        "username": "jayin",
+        "password": "123"
+    }
+    /* some comment */
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,14 @@
+const cp = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const cwd = path.join(__dirname, 'fixtures')
+const cliExpected = fs.readFileSync(path.join(cwd, 'result.json'), 'utf8')
+const apiExpected = require('./fixtures/result.json')
+
+exports.cli = function (args) {
+  let bin = path.join(__dirname, '../bin/jsonmerge.js')
+  return cp.spawnSync(bin, args, { cwd: cwd, encoding: 'utf8' })
+}
+exports.cliExpected = cliExpected
+exports.apiExpected = apiExpected


### PR DESCRIPTION
Principle: try to keep the most backward-compatibility

Use Case: I wanna use it this way: https://github.com/microsoft/vscode/issues/15909

```sh
jsonmerge --jsonc .vscode/settings_*.json > .vscode/settings.json
```

---

Changes:

### API

```javascript
const jsonmerge = require('jsonmerge')
let result = jsonmerge(['./test/fixtures/json/*.json'])

// or with jsonc support
const jsonmerge = require('jsonmerge/jsonc')
let result = jsonmerge(['./test/fixtures/jsonc/*.json'])

console.log(JSON.stringify(result, null, 4))
```

### CLI

```shell
$ cd test/fixtures
$ jsonmerge json/*.json > result.json

# or with jsonc support
$ jsonmerge --jsonc jsonc/*.json > result.json
```