### PR TITLE
Add CI workflows, badge & Compatibility table

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,58 @@
+name: e2e test
+
+on:
+  push:
+    branches: [master, ci/**]
+  pull_request:
+    branches: [master, ci/**]
+  workflow_dispatch:
+    # Keep this to allow for triggering manually
+
+jobs:
+  e2e-test:
+    strategy:
+      matrix:
+        # at the time jsonmerge was created (Feb 10, 2016):
+        # node versions: 0.10.x, 0.12.x, 4
+        # https://github.com/nodejs/node/blob/main/CHANGELOG.md
+        # os versions: windows-2016, ubuntu-14.04
+        # https://en.wikipedia.org/wiki/Ubuntu_version_history
+        node-version:
+          # trying to pick up the lowest versions within the supported options
+          # https://github.com/actions/node-versions/blob/main/versions-manifest.json
+          - 6
+          - 8
+          # - 10 # skip
+          # - 12 # skip
+          # - 14 # skip
+        os:
+          # trying to pick up the lowest versions within the supported options
+          # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
+          - windows-2019
+          - ubuntu-20.04
+          - macos-11
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: |
+          npm install --production
+          npm link
+      - name: Test Json
+        run: |
+          cd test/fixtures
+          jsonmerge json/*.json > tmp.json
+          node -e "assert.equal(fs.readFileSync('tmp.json','utf8'), fs.readFileSync('result.json','utf8'))"
+      - name: Test Jsonc
+        # current jsonc implementation requires node>=8
+        if: matrix.node-version == 8
+        run: |
+          cd test/fixtures
+          jsonmerge --jsonc jsonc/*.json > tmp.jsonc
+          node -e "assert.equal(fs.readFileSync('tmp.jsonc','utf8'), fs.readFileSync('result.json','utf8'))"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,37 @@
+name: unit test
+
+on:
+  push:
+    branches: [master, ci/**]
+  pull_request:
+    branches: [master, ci/**]
+  workflow_dispatch:
+    # Keep this to allow for triggering manually
+
+jobs:
+  unit-test:
+    strategy:
+      matrix:
+        node-version:
+          # currently devDependencies require node>=16
+          # - 16 # skip
+          - 18
+        os:
+          - ubuntu-22.04
+          - windows-2022
+          - macos-12
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# jsonmerge [![v](https://img.shields.io/npm/v/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge) [![dm](https://img.shields.io/npm/dm/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge)
+# jsonmerge [![v](https://img.shields.io/npm/v/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge) [![dm](https://img.shields.io/npm/dm/jsonmerge.svg)](https://www.npmjs.com/package/jsonmerge) [![unit](https://github.com/Jayin/jsonmerge/actions/workflows/unit-test.yml/badge.svg)](https://github.com/Jayin/jsonmerge/actions/workflows/unit-test.yml) [![e2e](https://github.com/Jayin/jsonmerge/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/Jayin/jsonmerge/actions/workflows/e2e-test.yml)
+)
 
 ## Install 
 
@@ -34,6 +35,19 @@ $ jsonmerge json/*.json > result.json
 # or with jsonc support
 $ jsonmerge --jsonc jsonc/*.json > result.json
 ```
+
+## Compatibility
+
+| os  | Windows | Ubuntu | MacOS |
+|:---:|:---:|:---:|:---:|
+| supported | ✅ | ✅ | ✅ |
+
+| node    | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| json    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| jsonc   | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+See also: [.github/workflows/](https://github.com/Jayin/jsonmerge/blob/master/.github/workflows/)
 
 ## License 
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint:fix": "eslint . --fix",
     "lint": "eslint .",
+    "test:cov": "c8 -x test -x strip-json-comments xv",
     "test": "xv"
   },
   "bin": {
@@ -33,6 +34,8 @@
     "strip-json-trailing-commas": "^1.1.0"
   },
   "devDependencies": {
+    "@cjs-mifi-test/execa": "^6.0.0",
+    "c8": "^7.12.0",
     "eslint": "^8.25.0",
     "eslint-config-fritx": "^0.0.3",
     "eslint-plugin-es5": "^1.5.0",

--- a/test/cli.default.test.js
+++ b/test/cli.default.test.js
@@ -21,6 +21,8 @@ exports.testEmptyInput = function () {
 
 exports.testJsonc = function () {
   let res = helper.cli(['jsonc/*.json'])
-  assert.equal(res.stdout, '')
+  assert.ok(res.error)
+  assert.match(res.error.message, /SyntaxError: Unexpected token/)
   assert.match(res.stderr, /SyntaxError: Unexpected token/)
+  assert.equal(res.stdout, '')
 }

--- a/test/fixtures/jsonc/b.json
+++ b/test/fixtures/jsonc/b.json
@@ -5,8 +5,8 @@
     "number": "2",
     "attrB": "B",
     "info": {
-        "password": "passwordB"
-    }
+        "password": "passwordB",
+    },
 }
 /**
   * block

--- a/test/fixtures/jsonc/c.json
+++ b/test/fixtures/jsonc/c.json
@@ -9,7 +9,7 @@
     // a comment
     "info": {
         "username": "jayin",
-        "password": "123"
+        "password": "123",
     }
     /* some comment */
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,14 +1,33 @@
-const cp = require('child_process')
+const cjsExecaPkg = require('@cjs-mifi-test/execa')
 const fs = require('fs')
 const path = require('path')
 
 const cwd = path.join(__dirname, 'fixtures')
-const cliExpected = fs.readFileSync(path.join(cwd, 'result.json'), 'utf8')
 const apiExpected = require('./fixtures/result.json')
+let cliExpected = fs.readFileSync(path.join(cwd, 'result.json'), 'utf8')
 
+// unify eol for testing
+if (process.platform === 'win32') {
+  cliExpected = cliExpected.replace(/\r\n/g, '\n')
+}
+
+// keep the similar behavior with `child_process.spawnSync` for testing
+// while fixing windows issues with `execa`
 exports.cli = function (args) {
   let bin = path.join(__dirname, '../bin/jsonmerge.js')
-  return cp.spawnSync(bin, args, { cwd: cwd, encoding: 'utf8' })
+  try {
+    return cjsExecaPkg.execaSync(bin, args, {
+      cwd: cwd,
+      encoding: 'utf8',
+      stripFinalNewline: false
+    })
+  } catch (err) {
+    return {
+      stdout: err.stdout,
+      stderr: err.stderr,
+      error: err
+    }
+  }
 }
 exports.cliExpected = cliExpected
 exports.apiExpected = apiExpected


### PR DESCRIPTION
[![unit](https://github.com/we-fork/jsonmerge/actions/workflows/unit-test.yml/badge.svg)](https://github.com/we-fork/jsonmerge/actions/workflows/unit-test.yml) [![e2e](https://github.com/we-fork/jsonmerge/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/we-fork/jsonmerge/actions/workflows/e2e-test.yml)

## Compatibility

| os  | Windows | Ubuntu | MacOS |
|:---:|:---:|:---:|:---:|
| supported | ✅ | ✅ | ✅ |

| node    | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| json    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| jsonc   | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

See also: [.github/workflows/](https://github.com/we-fork/jsonmerge/blob/ci/test/.github/workflows/)

## Coverage

<img width="879" alt="image" src="https://user-images.githubusercontent.com/6647633/196738489-9d2484f6-c7ec-46f6-aeb3-b9d02ce246c4.png">

