### PR TITLE
Drop node6 from CI e2e-test due to unknown bug in npm cli

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -20,9 +20,9 @@ jobs:
         node-version:
           # trying to pick up the lowest versions within the supported options
           # https://github.com/actions/node-versions/blob/main/versions-manifest.json
-          - 6
+          # - 6
           - 8
-          # - 10 # skip
+          - 10 # skip
           # - 12 # skip
           # - 14 # skip
         os:
@@ -51,7 +51,7 @@ jobs:
           node -e "assert.equal(fs.readFileSync('tmp.json','utf8'), fs.readFileSync('result.json','utf8'))"
       - name: Test Jsonc
         # current jsonc implementation requires node>=8
-        if: matrix.node-version == 8
+        if: matrix.node-version >= 8
         run: |
           cd test/fixtures
           jsonmerge --jsonc jsonc/*.json > tmp.jsonc

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,5 +37,14 @@ jobs:
         run: npm run test:cov
 
       - name: Update Coverage Badge
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.node-version == 18 }}
+        # Is there a way to tell if a PR is from a forked repository? #26829
+        # https://github.com/orgs/community/discussions/26829#discussioncomment-3253580
+        if: >-
+          matrix.os == 'ubuntu-22.04' && matrix.node-version == 18 && ((
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+          ) || (
+            github.event_name == 'pull_request_target' &&
+            github.event.pull_request.head.repo.full_name != github.repository
+          ))
         uses: we-cli/coverage-badge-action@main


### PR DESCRIPTION
Same e2e-test CI failed (after two years): https://github.com/Jayin/jsonmerge/actions/runs/7538260400/job/20518638753

Seems like it's a npm3 problem while `npm install`,related: https://github.com/npm/cli/issues/5032

Fix: Drop node6 from e2e-test CI
